### PR TITLE
Community garden easter egg

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -3,26 +3,31 @@ import Link from "next/link";
 export default function Footer() {
   return (
     <footer className="p-6 w-full">
-      <div className="pt-4 max-w-7xl m-auto text-sm text-stone-400 flex flex-col gap-2">
-        <h2>
-          PartyKit Next.js Chat Template{" "}
-          <Link
-            href="https://github.com/partykit/partykit-nextjs-chat-template"
-            className="bg-stone-200 p-2 rounded text-stone-600"
-          >
-            View on GitHub
-          </Link>
-        </h2>
-        <p>
-          Built with{" "}
-          <Link href="https://nextjs.org" className="underline">
-            Next.js
-          </Link>{" "}
-          and{" "}
-          <Link href="https://partykit.io" className="underline">
-            PartyKit
-          </Link>
-        </p>
+      <div className="pt-4 max-w-7xl m-auto text-sm text-stone-400 flex flex-row justify-between">
+        <div className="flex flex-col gap-2 justify-start">
+          <h2>
+            PartyKit Next.js Chat Template {" "}
+            (also a <Link href="/garden" className="underline">tiny garden</Link>)
+          </h2>
+          <p>
+            Built with{" "}
+            <Link href="https://nextjs.org" className="underline">
+              Next.js
+            </Link>{" "}
+            and{" "}
+            <Link href="https://partykit.io" className="underline">
+              PartyKit
+            </Link>
+          </p>
+        </div>
+        <div className="flex flex-col justify-end">
+        <Link
+              href="https://github.com/partykit/partykit-nextjs-chat-template"
+              className="bg-stone-200 hover:bg-stone-300 p-2 rounded text-stone-600"
+            >
+              View on GitHub
+            </Link>
+        </div>
       </div>
     </footer>
   );

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -61,14 +61,14 @@ export default function Garden() {
 
             <div className="flex flex-col justify-start items-start gap-2">
                 { starter && (
-                    <>
-                    <div className="bg-cyan-100 rounded text-4xl px-6 py-4">{starter.emoji} Plant me!</div>
-                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => handleGetStarter()}>Re-spin</button></p>
-                    </>
+                    <div className="flex flex-row justify-start items-end gap-4">
+                        <div className="bg-cyan-200 outline outline-2 outline-cyan-300 drop-shadow rounded-lg text-4xl px-6 py-4">{starter.emoji} Plant me!</div>
+                        <p className="text-sm text-stone-400 mb-2 text-lg"><button className="underline" onClick={() => handleGetStarter()}>Re-spin!</button></p>
+                    </div>
                 )}
                 { !starter && (
                     <>
-                    <button className="bg-cyan-100 rounded text-4xl px-6 py-4" onClick={() => handleGetStarter()}>Plant a seed!</button>
+                    <button className="bg-cyan-100 outline outline-2 outline-cyan-300 hover:bg-cyan-200 rounded-lg text-4xl px-6 py-4 drop-shadow-lg hover:drop-shadow" onClick={() => handleGetStarter()}>Get a seed!</button>
                     </>
                 )}
             </div>

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -46,7 +46,7 @@ export default function Garden() {
                     const cell = state.garden[i] ?? null;
                     return <button
                         key={i}
-                        className="bg-lime-100 w-10 h-10 flex justify-center items-center disabled:bg-stone-100 hover:bg-lime-200 disabled:cursor-not-allowed text-4xl overflow-clip"
+                        className="bg-lime-200 w-10 h-10 flex justify-center items-center hover:bg-lime-300 disabled:cursor-not-allowed text-4xl overflow-clip"
                         disabled={starter === null || cell !== null}
                         onClick={() => handlePlantEmoji(i)}
                         >

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -2,72 +2,69 @@
 
 import { useState } from "react";
 import { syncedStore, getYjsDoc } from "@syncedstore/core";
+import { useSyncedStore } from "@syncedstore/react";
 import YPartyKitProvider from "y-partykit/provider";
+import { getStarterEmojis, Cell, Garden, yDocShape, gardenDimensions } from "@/party/garden";
 
 const host = process.env.NEXT_PUBLIC_PARTYKIT_HOST!;
-
-const yDocShape = { garden: [] as string[] };
-
-// The initial garden is 25 empty squares
-const initialGarden = [...Array(64)].map(() => "");
-
-const emojiTrees = ["🌳", "🌲", "🌳", "🌲", "🌳", "🌲", "🌳", "🌲"];
-const emojiShrubs = ["🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", ];
-const emojiForestAnimals = ["🐿️", "🦌"];
-const allowedEmojis = [...emojiTrees, ...emojiShrubs, ...emojiForestAnimals];
 
 const store = syncedStore(yDocShape);
 const doc = getYjsDoc(store);
 
 export default function Garden() {
-    const [emojiToPlace, setEmojiToPlace] = useState<string | null>(null);
-    const [garden, setGarden] = useState<string[]>(initialGarden);
+    const [starter, setStarter] = useState<Cell>(null);
+    const gardenSize = gardenDimensions.width * gardenDimensions.height;
+    const state = useSyncedStore(store);
 
-    /*const provider = new YPartyKitProvider(
+    // A list of Cell { lineage, index, emoji } objects
+    const starterEmojis = getStarterEmojis();
+
+    const provider = new YPartyKitProvider(
         host,
         "shared-garden",
         doc,
-        {party: "garden"});*/
+        {party: "garden"});
 
     const handlePlantEmoji = (i: number) => {
-        if (emojiToPlace) {
-            const newGarden = [...garden];
-            newGarden[i] = emojiToPlace;
-            setGarden(newGarden);
-            setEmojiToPlace(null);
+        if (starter) {
+            // plant the starter emoji in the garden
+            state.garden[i] = starter;
+            setStarter(null);
         }
     }
 
-    const handleEmojiToPlant = () => {
-        const randomEmoji = allowedEmojis[Math.floor(Math.random() * allowedEmojis.length)];
-        setEmojiToPlace(randomEmoji);
+    const handleGetStarter = () => {
+        // get a random starter from the starterEmojis
+        const randomStarter = starterEmojis[Math.floor(Math.random() * starterEmojis.length)];
+        setStarter(randomStarter);
     }
 
     return (
         <div className="flex flex-col gap-6 justify-start items-start">
-            <div className="grid grid-cols-8 grid-rows-8">
-                { [...Array(64)].map((_, i) => (
-                    <button
+            <div className="grid grid-cols-10 grid-rows-10">
+                { [...Array(gardenSize)].map((_, i) => {
+                    const cell = state.garden[i] ?? null;
+                    return <button
                         key={i}
                         className="bg-lime-100 w-10 h-10 flex justify-center items-center disabled:bg-stone-100 hover:bg-lime-200 disabled:cursor-not-allowed text-4xl overflow-clip"
-                        disabled={emojiToPlace === null || garden[i] !== ""}
+                        disabled={starter === null || cell !== null}
                         onClick={() => handlePlantEmoji(i)}
                         >
-                        {garden[i]}
+                        {cell ? cell.emoji : ""}
                     </button>
-                ))}
+                })}
             </div>
 
             <div className="flex flex-col justify-start items-start gap-2">
-                { emojiToPlace && (
+                { starter && (
                     <>
-                    <div className="bg-cyan-100 rounded text-4xl px-6 py-4">{emojiToPlace} Plant me!</div>
-                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => handleEmojiToPlant()}>Re-spin</button></p>
+                    <div className="bg-cyan-100 rounded text-4xl px-6 py-4">{starter.emoji} Plant me!</div>
+                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => handleGetStarter()}>Re-spin</button></p>
                     </>
                 )}
-                { !emojiToPlace && (
+                { !starter && (
                     <>
-                    <button className="bg-cyan-100 rounded text-4xl px-6 py-4" onClick={() => handleEmojiToPlant()}>Plant a seed!</button>
+                    <button className="bg-cyan-100 rounded text-4xl px-6 py-4" onClick={() => handleGetStarter()}>Plant a seed!</button>
                     </>
                 )}
             </div>

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -45,12 +45,12 @@ export default function Garden() {
 
     return (
         <div className="flex flex-col gap-6 justify-start items-start">
-            <div className="grid grid-cols-10 grid-rows-10">
+            <div className="grid grid-cols-10 grid-rows-10 bg-lime-200">
                 { [...Array(gardenSize)].map((_, i) => {
                     const cell = state.garden[i] ?? null;
                     return <button
                         key={i}
-                        className="bg-lime-200 w-10 h-10 flex justify-center items-center hover:bg-lime-300 disabled:cursor-not-allowed text-4xl overflow-clip"
+                        className="bg-lime-200 w-10 h-10 flex justify-center items-center hover:bg-lime-300 hover:rounded-full disabled:rounded-none disabled:bg-lime-200 disabled:cursor-not-allowed text-4xl overflow-clip"
                         disabled={starter === null || cell !== null}
                         onClick={() => handlePlantEmoji(i)}
                         >

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { use, useEffect, useState } from "react";
 import { syncedStore, getYjsDoc } from "@syncedstore/core";
 import { useSyncedStore } from "@syncedstore/react";
 import YPartyKitProvider from "y-partykit/provider";
@@ -23,7 +23,11 @@ export default function Garden() {
         host,
         "shared-garden",
         doc,
-        {party: "garden"});
+        {party: "garden", connect: false});
+
+    useEffect(() => {
+        provider.connect();
+    }, [provider]);
 
     const handlePlantEmoji = (i: number) => {
         if (starter) {

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -1,22 +1,33 @@
 "use client";
 
 import { useState } from "react";
+import { syncedStore, getYjsDoc } from "@syncedstore/core";
+import YPartyKitProvider from "y-partykit/provider";
+
+const host = process.env.NEXT_PUBLIC_PARTYKIT_HOST!;
+
+const yDocShape = { garden: [] as string[] };
 
 // The initial garden is 25 empty squares
-const initialGarden = [...Array(25)].map(() => "");
+const initialGarden = [...Array(64)].map(() => "");
 
-const allowedEmojis = ["🌱", "🌿", "🌵", "🌳", "🌴", "🌲", "🌾", "🌺", "🌻", "🌼"];
+const emojiTrees = ["🌳", "🌲", "🌳", "🌲", "🌳", "🌲", "🌳", "🌲"];
+const emojiShrubs = ["🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", "🌱", ];
+const emojiForestAnimals = ["🐿️", "🦌"];
+const allowedEmojis = [...emojiTrees, ...emojiShrubs, ...emojiForestAnimals];
+
+const store = syncedStore(yDocShape);
+const doc = getYjsDoc(store);
 
 export default function Garden() {
     const [emojiToPlace, setEmojiToPlace] = useState<string | null>(null);
     const [garden, setGarden] = useState<string[]>(initialGarden);
 
-    // Random pastel color generator
-    const randomColor = () => {
-        const hue = Math.floor(Math.random() * 360);
-        const pastel = 'hsl(' + hue + ', 100%, 87.5%)';
-        return pastel;
-    }
+    /*const provider = new YPartyKitProvider(
+        host,
+        "shared-garden",
+        doc,
+        {party: "garden"});*/
 
     const handlePlantEmoji = (i: number) => {
         if (emojiToPlace) {
@@ -34,11 +45,11 @@ export default function Garden() {
 
     return (
         <div className="flex flex-col gap-6 justify-start items-start">
-            <div className="grid grid-cols-5 grid-rows-5">
-                { [...Array(25)].map((_, i) => (
+            <div className="grid grid-cols-8 grid-rows-8">
+                { [...Array(64)].map((_, i) => (
                     <button
                         key={i}
-                        className="bg-lime-100 w-10 h-10 flex justify-center items-center disabled:bg-stone-100 hover:bg-lime-200 disabled:cursor-not-allowed"
+                        className="bg-lime-100 w-10 h-10 flex justify-center items-center disabled:bg-stone-100 hover:bg-lime-200 disabled:cursor-not-allowed text-4xl overflow-clip"
                         disabled={emojiToPlace === null || garden[i] !== ""}
                         onClick={() => handlePlantEmoji(i)}
                         >
@@ -51,7 +62,7 @@ export default function Garden() {
                 { emojiToPlace && (
                     <>
                     <div className="bg-cyan-100 rounded text-4xl px-6 py-4">{emojiToPlace} Plant me!</div>
-                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => setEmojiToPlace(null)}>Cancel</button></p>
+                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => handleEmojiToPlant()}>Re-spin</button></p>
                     </>
                 )}
                 { !emojiToPlace && (

--- a/app/garden/Garden.tsx
+++ b/app/garden/Garden.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useState } from "react";
+
+// The initial garden is 25 empty squares
+const initialGarden = [...Array(25)].map(() => "");
+
+const allowedEmojis = ["🌱", "🌿", "🌵", "🌳", "🌴", "🌲", "🌾", "🌺", "🌻", "🌼"];
+
+export default function Garden() {
+    const [emojiToPlace, setEmojiToPlace] = useState<string | null>(null);
+    const [garden, setGarden] = useState<string[]>(initialGarden);
+
+    // Random pastel color generator
+    const randomColor = () => {
+        const hue = Math.floor(Math.random() * 360);
+        const pastel = 'hsl(' + hue + ', 100%, 87.5%)';
+        return pastel;
+    }
+
+    const handlePlantEmoji = (i: number) => {
+        if (emojiToPlace) {
+            const newGarden = [...garden];
+            newGarden[i] = emojiToPlace;
+            setGarden(newGarden);
+            setEmojiToPlace(null);
+        }
+    }
+
+    const handleEmojiToPlant = () => {
+        const randomEmoji = allowedEmojis[Math.floor(Math.random() * allowedEmojis.length)];
+        setEmojiToPlace(randomEmoji);
+    }
+
+    return (
+        <div className="flex flex-col gap-6 justify-start items-start">
+            <div className="grid grid-cols-5 grid-rows-5">
+                { [...Array(25)].map((_, i) => (
+                    <button
+                        key={i}
+                        className="bg-lime-100 w-10 h-10 flex justify-center items-center disabled:bg-stone-100 hover:bg-lime-200 disabled:cursor-not-allowed"
+                        disabled={emojiToPlace === null || garden[i] !== ""}
+                        onClick={() => handlePlantEmoji(i)}
+                        >
+                        {garden[i]}
+                    </button>
+                ))}
+            </div>
+
+            <div className="flex flex-col justify-start items-start gap-2">
+                { emojiToPlace && (
+                    <>
+                    <div className="bg-cyan-100 rounded text-4xl px-6 py-4">{emojiToPlace} Plant me!</div>
+                    <p className="text-sm text-stone-400">Click on a square to plant your emoji. <button className="underline" onClick={() => setEmojiToPlace(null)}>Cancel</button></p>
+                    </>
+                )}
+                { !emojiToPlace && (
+                    <>
+                    <button className="bg-cyan-100 rounded text-4xl px-6 py-4" onClick={() => handleEmojiToPlant()}>Plant a seed!</button>
+                    </>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/app/garden/page.tsx
+++ b/app/garden/page.tsx
@@ -1,7 +1,14 @@
+import Link from 'next/link';
 import Garden from './Garden';
 
 export default function Page() {
     return (
+        <div className="flex flex-col gap-4">
+        <h1 className="text-4xl font-medium">Tiny Community Garden</h1>
+        <p className="max-w-xl pb-6">
+            Plant a seed and see it evolve! See the same garden in other browsers! This demo shows <Link href="https://yjs.dev" className="underline">Yjs</Link> syncing document state, and PartyKit updating the shared doc independently of the clients.
+        </p>
         <Garden />
-    )
+      </div>
+      )
 }

--- a/app/garden/page.tsx
+++ b/app/garden/page.tsx
@@ -1,0 +1,7 @@
+import Garden from './Garden';
+
+export default function Page() {
+    return (
+        <Garden />
+    )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "partykit-nextjs-chat-template",
       "version": "0.1.0",
       "dependencies": {
+        "@syncedstore/core": "^0.5.2",
+        "@syncedstore/react": "^0.5.2",
         "@types/node": "20.4.2",
         "@types/react": "18.2.15",
         "@types/react-dom": "18.2.7",
@@ -25,7 +27,8 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.3",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "y-partykit": "^0.0.0-e1bebe6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -853,6 +856,22 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@reactivedata/react": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@reactivedata/react/-/react-0.2.1.tgz",
+      "integrity": "sha512-nNnZaT3MDisDicXIX5/YvXZoVE0uO5LB47zTIs+hBnDRUAAYAzD8l+RcIa1YzouaOLK0yIx3ffwIvfGy/bJWjg==",
+      "dependencies": {
+        "@reactivedata/reactive": "^0.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/@reactivedata/reactive": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@reactivedata/reactive/-/reactive-0.2.0.tgz",
+      "integrity": "sha512-qWmVSmUrjKHBiD+ZS8TxNNzyk9J6rbcZSZJgcnKQpTLwORZoWuX5pYbl07aU0kzXGLaaVX2O/ZW+SZaBjRQW3g=="
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.2.tgz",
@@ -866,11 +885,60 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@syncedstore/core": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@syncedstore/core/-/core-0.5.2.tgz",
+      "integrity": "sha512-gg1cJwhdwF806smc8xfuGk4bH4JRgKN7HqCt383ZvyA2MySEOlyvZf49XOdwz+zia4bE2T/oBfkcBNgZrQNubg==",
+      "dependencies": {
+        "@reactivedata/reactive": "0.2.0",
+        "@syncedstore/yjs-reactive-bindings": "^0.5.2",
+        "@types/eslint": "6.8.0"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.13"
+      }
+    },
+    "node_modules/@syncedstore/react": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@syncedstore/react/-/react-0.5.2.tgz",
+      "integrity": "sha512-A1ufRZ33AnO6bTllfYOTEpHVrHQsPRg+oIWvZiAzUw1d5BCZYT3xoqPQmekZBsOScFORKCZp+ZUCUQTclT/ImQ==",
+      "dependencies": {
+        "@reactivedata/react": "0.2.1",
+        "@types/eslint": "6.8.0"
+      },
+      "peerDependencies": {
+        "@syncedstore/core": "*"
+      }
+    },
+    "node_modules/@syncedstore/yjs-reactive-bindings": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@syncedstore/yjs-reactive-bindings/-/yjs-reactive-bindings-0.5.2.tgz",
+      "integrity": "sha512-5y4aUtZoDuvpnlCj2RxTR7P0UuQeF9SfL2K3S+JAqihYWECX8YEa0GvGRWgU7CEPpnLcFXkiSxDqgk87wu7fHw==",
+      "dependencies": {
+        "@types/eslint": "6.8.0"
+      },
+      "peerDependencies": {
+        "yjs": "^13.5.13"
+      }
+    },
+    "node_modules/@types/eslint": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-6.8.0.tgz",
+      "integrity": "sha512-hqzmggoxkOubpgTdcOltkfc5N8IftRJqU70d1jbOISjjZVPvjcr+CLi2CI70hx1SUIRkLgpglTy9w28nGe2Hsw==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
-      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
-      "peer": true
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
+      "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3994,6 +4062,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/jiti": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.19.1.tgz",
@@ -4094,6 +4171,25 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lib0": {
+      "version": "0.2.78",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
+      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -4131,6 +4227,11 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6811,6 +6912,29 @@
         }
       }
     },
+    "node_modules/y-partykit": {
+      "version": "0.0.0-e1bebe6",
+      "resolved": "https://registry.npmjs.org/y-partykit/-/y-partykit-0.0.0-e1bebe6.tgz",
+      "integrity": "sha512-kyrh/fLjKND8ZgUueke49h9ybYdGZ2z0b3dVB5PKtJiYA6I+qqLgkrrRmKqotoQF9pCNEW0dweXLv0JAiofB3g==",
+      "dependencies": {
+        "lib0": "^0.2.60",
+        "lodash.debounce": "^4.0.8",
+        "y-protocols": "^1.0.5",
+        "yjs": "^13.5.44"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
+      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
+      "dependencies": {
+        "lib0": "^0.2.42"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
@@ -6822,6 +6946,22 @@
       "integrity": "sha512-2eHWfjaoXgTBC2jNM1LRef62VQa0umtvRiDSk6HSzW7RvS5YtkabJrwYLLEKWBc8a5U2PTSCs+dJjUTJdlHsWQ==",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.7",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.7.tgz",
+      "integrity": "sha512-mCZTh4kjvUS2DnaktsYN6wLH3WZCJBLqrTdkWh1bIDpA/sB/GNFaLA/dyVJj2Hc7KwONuuoC/vWe9bwBBosZLQ==",
+      "dependencies": {
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6",
-        "y-partykit": "^0.0.0-e1bebe6"
+        "y-partykit": "^0.0.0-9a4b594"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6913,9 +6913,9 @@
       }
     },
     "node_modules/y-partykit": {
-      "version": "0.0.0-e1bebe6",
-      "resolved": "https://registry.npmjs.org/y-partykit/-/y-partykit-0.0.0-e1bebe6.tgz",
-      "integrity": "sha512-kyrh/fLjKND8ZgUueke49h9ybYdGZ2z0b3dVB5PKtJiYA6I+qqLgkrrRmKqotoQF9pCNEW0dweXLv0JAiofB3g==",
+      "version": "0.0.0-9a4b594",
+      "resolved": "https://registry.npmjs.org/y-partykit/-/y-partykit-0.0.0-9a4b594.tgz",
+      "integrity": "sha512-xXVBi7iS2YJIwmwbwfsCCyVQEv1uJOCZrovtk6rf7ut9mBefwRthWiXSYnpBCsiFo0LN6L7Hv6OAxJde2k4mVA==",
       "dependencies": {
         "lib0": "^0.2.60",
         "lodash.debounce": "^4.0.8",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6",
-    "y-partykit": "^0.0.0-e1bebe6"
+    "y-partykit": "^0.0.0-9a4b594"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@syncedstore/core": "^0.5.2",
+    "@syncedstore/react": "^0.5.2",
     "@types/node": "20.4.2",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",
@@ -26,6 +28,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.3",
-    "typescript": "5.1.6"
+    "typescript": "5.1.6",
+    "y-partykit": "^0.0.0-e1bebe6"
   }
 }

--- a/party/garden.ts
+++ b/party/garden.ts
@@ -52,5 +52,21 @@ export const getStarterEmojis = () => {
     }) as Cell[];
 }
 
-
-export default { onConnect };
+export default {
+    onConnect(ws, room) {
+        return onConnect(ws, room, {
+            callback: {
+                async handler(ydoc) {
+                    try {
+                        // @TODO Stash the ydoc and set an alarm if it isn't empty
+                    } catch (e) {
+                        console.error("Callback error", e);
+                    }
+                }
+            },
+        });
+    },
+    async onAlarm(room) {
+        // @TODO iterate the garden and set a new alarm if the garden isn't empty
+    }
+} satisfies PartyKitServer;

--- a/party/garden.ts
+++ b/party/garden.ts
@@ -1,6 +1,10 @@
-import { PartyKitServer } from "partykit/server";
+import { PartyKitServer, PartyKitRoom } from "partykit/server";
 import { onConnect } from "y-partykit";
 import { syncedStore, getYjsDoc } from "@syncedstore/core";
+
+type YJsRoom = PartyKitRoom & {
+    store?: any;
+}
 
 type Lineage = string[];
 
@@ -33,7 +37,7 @@ const lineages = {
     squirrel: ["🌰", "🌰", "🌰", "🐿️", "🐿️"],
     sprout: ["🌱", "🌱", "🌱", "🌱", "🍄", "🍄", "🍄", "🦌", "🦌"],
     flower: ["🌱", "🌱", "🌸", "🌸", "🌸", "🌸", "🌸", "🌸", "🐝", "🐝"],
-    fern: ["🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🐻", "👣", "👣", "👣"]
+    fern: ["🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🐻", "🐻", "👣", "👣"]
 } as Lineages;
 
 export const yDocShape = { garden: {} as Garden };
@@ -52,13 +56,29 @@ export const getStarterEmojis = () => {
     }) as Cell[];
 }
 
+const GARDEN_TICK = 1500; // milliseconds
+
 export default {
     onConnect(ws, room) {
         return onConnect(ws, room, {
             callback: {
                 async handler(ydoc) {
                     try {
-                        // @TODO Stash the ydoc and set an alarm if it isn't empty
+                        // Stash the ydoc and set an alarm if it isn't empty
+                        if (!(room as YJsRoom).store) {
+                            const store = syncedStore(yDocShape, ydoc);
+                            //console.log("Stashing store", store);
+                            (room as YJsRoom).store = store;
+                        }
+                        // If there's no alarm set, set one for the next tick
+                        const alarm = await room.storage.getAlarm();
+                        //console.log("alarm", alarm);
+                        if (alarm === null) {
+                            //console.log("Setting alarm");
+                            await room.storage.setAlarm(
+                                new Date().getTime() + GARDEN_TICK
+                            );
+                        }
                     } catch (e) {
                         console.error("Callback error", e);
                     }
@@ -67,6 +87,33 @@ export default {
         });
     },
     async onAlarm(room) {
-        // @TODO iterate the garden and set a new alarm if the garden isn't empty
+        //console.log("onAlarm: iterating garden");
+        // iterate the garden and set a new alarm if the garden isn't empty
+        const store = (room as YJsRoom).store;
+        Object.entries(store.garden as Garden).forEach(([index, cell]) => {
+            if (cell) {
+                // Check the lineage and index against the lineages map
+                // If the index can be incremented, increment it and update the emoji.
+                // If it can't be incremented, remove the cell from the garden.
+                const lineage = lineages[cell.lineage];
+                if (lineage) {
+                    if (cell.index < lineage.length - 1) {
+                        cell.index++;
+                        cell.emoji = lineage[cell.index];
+                    } else {
+                        delete store.garden[index];
+                    }
+                } else {
+                    delete store.garden[index];
+                }
+            }
+        });
+
+        // Set the alarm if the garden isn't empty
+        if (store.garden.size > 0) {
+            await room.storage.setAlarm(
+                new Date().getTime() + GARDEN_TICK
+            );
+        }
     }
 } satisfies PartyKitServer;

--- a/party/garden.ts
+++ b/party/garden.ts
@@ -1,0 +1,4 @@
+import { PartyKitServer } from "partykit/server";
+import { onConnect } from "y-partykit";
+
+export default { onConnect };

--- a/party/garden.ts
+++ b/party/garden.ts
@@ -1,4 +1,56 @@
 import { PartyKitServer } from "partykit/server";
 import { onConnect } from "y-partykit";
+import { syncedStore, getYjsDoc } from "@syncedstore/core";
+
+type Lineage = string[];
+
+type Lineages = {
+    [key: string]: Lineage;
+}
+
+type PopulatedCell = {
+    lineage: string;
+    index: number;
+    emoji: string;
+}
+
+export type Cell = PopulatedCell | null;
+
+// Garden is a map of index to cell
+// The index is left to right, top to bottom
+export type Garden = {
+    [key: number]: Cell;
+}
+
+export const gardenDimensions = {
+    width: 10,
+    height: 10
+}
+
+const lineages = {
+    deciduous: ["🌱", "🌳", "🌳", "🌳", "🌳", "🌳", "🍂", "🐌"],
+    evergreen: ["🌰", "🌲", "🌲", "🌲", "🌲", "🌲", "🍃"],
+    squirrel: ["🌰", "🌰", "🌰", "🐿️", "🐿️"],
+    sprout: ["🌱", "🌱", "🌱", "🌱", "🍄", "🍄", "🍄", "🦌", "🦌"],
+    flower: ["🌱", "🌱", "🌸", "🌸", "🌸", "🌸", "🌸", "🌸", "🐝", "🐝"],
+    fern: ["🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🌿", "🐻", "👣", "👣", "👣"]
+} as Lineages;
+
+export const yDocShape = { garden: {} as Garden };
+//export const store = syncedStore(yDocShape);
+//export const doc = getYjsDoc(store);
+
+export const getStarterEmojis = () => {
+    // returns a list of { lineage, emoji } objects where the emoji is the
+    // first emoji in the lineage
+    return Object.keys(lineages).map((lineage) => {
+        return {
+            lineage,
+            index: 0,
+            emoji: lineages[lineage][0]
+        }
+    }) as Cell[];
+}
+
 
 export default { onConnect };

--- a/party/garden.ts
+++ b/party/garden.ts
@@ -61,6 +61,7 @@ const GARDEN_TICK = 1500; // milliseconds
 export default {
     onConnect(ws, room) {
         return onConnect(ws, room, {
+            persist: true,
             callback: {
                 async handler(ydoc) {
                     try {

--- a/partykit.json
+++ b/partykit.json
@@ -6,6 +6,7 @@
     "chatrooms": "party/chatRooms.ts",
     "user": "party/user.ts",
     "ai": "party/ai.ts",
-    "cursors": "party/cursors.ts"
+    "cursors": "party/cursors.ts",
+    "garden": "party/garden.ts"
   }
 }


### PR DESCRIPTION
We'd like to have a lightweight YJs example in the starter kit, and this is a candidate for it.

- A link to a "garden" page is tucked in the footer (or it could be behind a disclosure on the homepage)
- In the garden, users can plant seeds. On the party-side, the seeds evolve through a sequence of emojis and eventually disappear
- On the party-side, the ydoc needs to be stashed on the room, and then iterated on an alarm. If the doc isn't empty then the alarm should be set again for another "tick"
- To do after merging: tidy the design

<img width="764" alt="image" src="https://github.com/partykit/partykit-nextjs-chat-template/assets/265390/e606bd1f-f857-495a-b2c5-da8410f15d9f">
