### PR TITLE
Support OpenAI API Base path configuration option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,4 @@ GITHUB_SECRET=
 # [PROD] You'll need to set this variable with `npx partykit env`
 OPENAI_API_KEY=
 OPENAI_API_ORGANIZATION=
-
+OPENAI_API_BASE_PATH=

--- a/party/utils/openai.ts
+++ b/party/utils/openai.ts
@@ -17,6 +17,7 @@ export async function getChatCompletionResponse(
     new Configuration({
       organization: env.OPENAI_API_ORGANIZATION,
       apiKey: env.OPENAI_API_KEY,
+      basePath: env.OPENAI_API_BASE_PATH,
     })
   );
 


### PR DESCRIPTION
Add support for `basePath` OpenAI configuration option.
This will allow to develop with local LLM (using [LM Studio](https://lmstudio.ai/) or [Ollama AI ](https://ollama.ai/)+ [LiteLLM](https://litellm.ai/)  proxy) or use Azure OpenAI API endpoints.